### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/auto-complete-auctex.el
+++ b/auto-complete-auctex.el
@@ -4,6 +4,7 @@
      
 ;; Author: Christopher Monsanto <chris@monsan.to>
 ;; Version: 1.0
+;; Package-Requires: ((yasnippet "0.6.1") (auto-complete "1.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -239,9 +240,4 @@
 (provide 'auto-complete-auctex)
 
 ;;; auto-complete-auctex.el ends here
-
-
-
-
-
 


### PR DESCRIPTION
Context: we're adding `auto-complete-auctex` to MELPA, and it would be nice if the dependencies were specified as fully as possible. See https://github.com/milkypostman/melpa/pull/1409
